### PR TITLE
1707 Using second instead of millisecond in precision

### DIFF
--- a/lib/cq/test_influx_db.go
+++ b/lib/cq/test_influx_db.go
@@ -14,7 +14,7 @@ const (
 	nTestRecord       = 100
 	recordInterval    = 1000
 	tags              = "abc"
-	timePrecision     = "ms"
+	timePrecision     = "s"
 )
 
 //setupTestInfluxClient return a http influxClient and create test Database

--- a/lib/tokenrate/fetcher.go
+++ b/lib/tokenrate/fetcher.go
@@ -91,7 +91,7 @@ func (ef *ETHUSDRateFetcher) queryDB(clnt client.Client, cmd string) (res []clie
 func (ef ETHUSDRateFetcher) SaveTokenRate(rate ETHUSDRate) error {
 	bp, err := client.NewBatchPoints(client.BatchPointsConfig{
 		Database:  ef.dbName,
-		Precision: "ms",
+		Precision: "s",
 	})
 	if err != nil {
 		return err

--- a/tradelogs/storage/influx.go
+++ b/tradelogs/storage/influx.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	//timePrecision is the precision configured for influxDB
-	timePrecision = "ms"
+	timePrecision = "s"
 )
 
 // InfluxStorage represent a client to store trade data to influx DB


### PR DESCRIPTION
As I check:

-  tradelogs storage are all using time.Time format instead of ms (https://github.com/KyberNetwork/reserve-stats/blob/optimize_time_precision/tradelogs/storage/interface.go) -> not affected

- reserverates storage already convert from millisecond to second (https://github.com/KyberNetwork/reserve-stats/blob/bbc3463b63e7a3463fe1d292cc86b218b84e1538/reserverates/storage/influx/rates_influxdb.go#L322) -> already use second

-> AFAIK, other packages does not use influxdb