### PR TITLE
2989 Refactor to date

### DIFF
--- a/accounting/cmd/accounting-reserve-rate-fetcher/main.go
+++ b/accounting/cmd/accounting-reserve-rate-fetcher/main.go
@@ -168,7 +168,7 @@ func run(c *cli.Context) error {
 		return err
 	}
 
-	toDate, err := timeutil.FromTimeFromContext(c)
+	toDate, err := timeutil.ToTimeFromContext(c)
 	switch err {
 	case timeutil.ErrEmptyFlag:
 		sugar.Info("toDate not provide. Fetcher running till now...")


### PR DESCRIPTION
I checked again. Only the toDate params is wrong. The lastBlockResolve work with fromDate correctly. It used to be the toDate was set equal to fromDate make me misunderstand that.