### PR TITLE
allow overwrite when re-run tradelog with psql db

### DIFF
--- a/lib/blockchain/mock_token_amount_formatter.go
+++ b/lib/blockchain/mock_token_amount_formatter.go
@@ -16,12 +16,25 @@ type MockTokenAmountFormatter struct {
 }
 
 // ToWei return the given human friendly number to wei unit.
-func (mc *MockTokenAmountFormatter) ToWei(_ common.Address, _ float64) (*big.Int, error) {
-	return big.NewInt(100), nil
+func (mc *MockTokenAmountFormatter) ToWei(_ common.Address, amount float64) (*big.Int, error) {
+	decimals := 18
+	exp := big.NewInt(0).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil)
+	result, _ := big.NewFloat(0).Mul(big.NewFloat(amount), big.NewFloat(0).SetInt(exp)).Int(nil)
+	return result, nil
 }
 
 // FromWei formats the given amount in wei to human friendly
 // number with preconfigured token decimals.
-func (mc *MockTokenAmountFormatter) FromWei(_ common.Address, _ *big.Int) (float64, error) {
-	return 9.99, nil
+func (mc *MockTokenAmountFormatter) FromWei(_ common.Address, amount *big.Int) (float64, error) {
+	if amount == nil {
+		return 0, nil
+	}
+	decimals := 18
+	floatAmount := new(big.Float).SetInt(amount)
+	power := new(big.Float).SetInt(new(big.Int).Exp(
+		big.NewInt(10), big.NewInt(int64(decimals)), nil,
+	))
+	res := new(big.Float).Quo(floatAmount, power)
+	result, _ := res.Float64()
+	return result, nil
 }

--- a/tradelogs/storage/postgres/postgres.go
+++ b/tradelogs/storage/postgres/postgres.go
@@ -361,8 +361,34 @@ INSERT INTO "` + schema.TradeLogsTableName + `"(
 	:tx_sender,
  	:receiver_address
 )
-ON CONFLICT
-DO NOTHING;`
+ON CONFLICT (tx_hash, index)
+DO 
+UPDATE SET -- update every fields if record exists (except field is_first_trade)
+	timestamp = :timestamp,
+	block_number = :block_number,
+	eth_amount = :eth_amount,
+	original_eth_amount = :original_eth_amount,
+ 	user_address_id = (SELECT id FROM users WHERE address=:user_address),
+ 	src_address_id = (SELECT id FROM token WHERE address=:src_address),
+ 	dst_address_id = (SELECT id FROM token WHERE address=:dst_address),
+ 	src_reserve_address_id = (SELECT id FROM reserve WHERE address=:src_reserve_address),
+ 	dst_reserve_address_id = (SELECT id FROM reserve WHERE address=:dst_reserve_address),
+ 	src_amount = :src_amount,
+ 	dst_amount = :dst_amount,
+ 	wallet_address_id = (SELECT id FROM wallet WHERE address=:wallet_address),
+ 	src_burn_amount = :src_burn_amount,
+ 	dst_burn_amount = :dst_burn_amount,
+ 	src_wallet_fee_amount = :src_wallet_fee_amount,
+ 	dst_wallet_fee_amount = :dst_wallet_fee_amount,
+ 	integration_app = :integration_app,
+ 	ip = :ip,
+ 	country = :country,
+ 	eth_usd_rate = :eth_usd_rate,
+ 	eth_usd_provider = :eth_usd_provider,
+	kyced = :kyced,
+	tx_sender = :tx_sender,
+	receiver_address = :receiver_address
+;`
 
 const selectTradeLogsQuery = `
 SELECT a.timestamp AS timestamp, block_number, eth_amount, original_eth_amount, eth_usd_rate, d.address AS user_address,


### PR DESCRIPTION
- when run tradelogs-crawler with flag db-engine=postgres, allow to overwrite record, therefore avoid dropping db  